### PR TITLE
Include installation instructions in docs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,7 @@
+version: 2
+
+python:
+  version: 3.7
+  install:
+    - requirements: docs/requirements.txt
+    - requirements: requirements.txt

--- a/README.md
+++ b/README.md
@@ -16,44 +16,44 @@ nodes.
 
 Laserfarm requires the [PDAL](https://pdal.io) and [GDAL](https://gdal.org) libraries and the PDAL Python 
 bindings. These packages are most easily installed through `conda` from the `conda-forge` channel:
-```shell script
+```shell
 conda install pdal python-pdal gdal -c conda-forge
 ```
 Laserfarm can then be downloaded and installed using `pip`:
-```shell script
+```shell
 pip install laserfarm
 ```
 or using `git` + `pip`:
-```shell script
+```shell
 git clone git@github.com:eEcoLiDAR/Laserfarm.git
 cd Laserfarm
 pip install .
 ```
 In order to setup a new conda environment with Laserfarm and all its dependencies, the YAML file provided can be 
 employed:
-```shell script
+```shell
 conda env create -f environment.yml
 ```
 
-# Documentation
+## Documentation
 
 The project's full documentation can be found [here](https://laserfarm.readthedocs.io/en/latest/).
 
-# Applications and Current Limitations
+## Applications and Current Limitations
 
 This package has been tested on data provided in a metric-based 2D-projected Cartesian coordinate system, i.e. the 
-*[Actueel Hoogtebestand Nederland](https://www.pdok.nl/introductie/-/article/actueel-hoogtebestand-nederland-ahn3-)*. 
+[Actueel Hoogtebestand Nederland](https://www.pdok.nl/introductie/-/article/actueel-hoogtebestand-nederland-ahn3-). 
 While some of the tools of Laserfarm could be applied to data in an ellipsoidal latitude/longitude coordinate system 
 as well, this has not been tested and it is generally expected to fail. 
 
-# Contributing
+## Contributing
 
 If you want to contribute to the development of Laserfarm,
 have a look at the  [contribution guidelines](CONTRIBUTING.md).
 
-# License
+## License
 
-Copyright (c) 2020, Netherlands eScience Center
+Copyright (c) 2022, Netherlands eScience Center
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -40,7 +40,7 @@ latex_logo = 'figures/ESCIENCE_logo_C_nl_cyanblack.png'
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ['sphinx.ext.autodoc', 'sphinx.ext.napoleon']
+extensions = ['sphinx.ext.autodoc', 'sphinx.ext.napoleon', 'm2r2']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -23,5 +23,6 @@ have a look at the  `contribution guidelines`_.
    :maxdepth: 2
    :caption: Contents:
 
+   readme 
    user_manual
 

--- a/docs/readme.rst
+++ b/docs/readme.rst
@@ -1,0 +1,2 @@
+
+.. mdinclude:: ../README.md

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,2 @@
+sphinx
+m2r2


### PR DESCRIPTION
Done by importing README file in docs, closes #51. Docs temporally shown [here](https://laserfarm.readthedocs.io/en/issue-51/index.html), branch will be disabled once merged. 